### PR TITLE
Uitsluitend de knop van type submit wordt geselecteerd als submit knop

### DIFF
--- a/src/vl-search-filter.js
+++ b/src/vl-search-filter.js
@@ -107,7 +107,7 @@ export class VlSearchFilter extends nativeVlElement(HTMLDivElement) {
   get _submitButton() {
     let button;
     if (this._formElement) {
-      button = this._formElement.querySelector('button');
+      button = this._formElement.querySelector(':scope > div button[type="submit"]');
     }
     if (!button && this._footerModalElement) {
       button = this._footerModalElement.querySelector('button');

--- a/test/unit/vl-search-filter.test.html
+++ b/test/unit/vl-search-filter.test.html
@@ -33,8 +33,11 @@
             </div>
           </section>
           <div>
-            <button is="vl-button" type="submit">
+            <button id="submit-button" is="vl-button" type="submit">
               Zoeken
+            </button>
+            <button id="button" is="vl-button">
+              Secundaire actie
             </button>
           </div>
         </form>
@@ -272,6 +275,12 @@
             done();
           });
         });
+      });
+
+      test('uitsluitend de button met type submit zal fungeren als submit button', () => {
+        const searchFilter = fixture('vl-search-filter-form-fixture');
+        assert.notEqual(searchFilter._submitButton, searchFilter.querySelector('#button'));
+        assert.equal(searchFilter._submitButton, searchFilter.querySelector('#submit-button'));
       });
 
       const assertClasses = (searchFilter) => {


### PR DESCRIPTION
Wanneer de vl-ui-multiselect gebruikt wordt in de filter, verschijnen er ook elementen van type button. De submit button selector was niet specifiek genoeg waardoor één van de multiselect button elementen geselecteerd werd als submit knop.